### PR TITLE
Fixed results refresh bug

### DIFF
--- a/src/components/appbody.js
+++ b/src/components/appbody.js
@@ -14,33 +14,29 @@ angular.module('n-queens')
  //    });
 
 	// },
-  controller: function(queen) {
+  controller: function(queen, $scope) {
     this.value = '';
-    this.values = [];
-    this.changeValue = (val) => {
-      this.value = val;
+    $scope.values = [];
+    this.changeValue = function(val) {
       console.log("test");
-      this.values = queen.runQueen(val);
+      queen.runQueen.call(this, val, this.setValues);
       this.value = '';
       console.log(this);
     };
+    this.setValues = function(vals) {
+      $scope.values = vals;
+      $scope.$apply();
+    };
+    this.changeValue = this.changeValue.bind(this);
   },
   bindings: {
 
   },
-  // template: `
-  //   <div id="appbody">
-  //     <inputline value="value" change-value="$ctrl.changeValue"> </inputline>
-
-  //     <results values="values"> </results>
-
-  //   </div>
-  // `
   template: `
     <div id="appbody">
       <inputline value="$ctrl.value" change-value="$ctrl.changeValue"> </inputline>
 
-      <results values="$ctrl.values"> </results>
+      <results values="values"> </results>
 
     </div>
   `

--- a/src/components/inputline.js
+++ b/src/components/inputline.js
@@ -6,7 +6,6 @@ angular.module('n-queens')
   bindings: {
     value: "=",
     changeValue: "<"
-
   },
   template: `
     <div>

--- a/src/components/results.js
+++ b/src/components/results.js
@@ -1,24 +1,21 @@
 angular.module('n-queens')
 
   .component('results', {
-    controller: function($scope) {
+    controller: function() {
 
     },
     bindings: {
-      values: "<"
+      values: '<'
     },
     template: `
     <div>
       <h1> results </h1>
       {{ $ctrl.values }}
       	<ul>
-	      <li
-	        ng-repeat="count in $ctrl.values"
-	      >
+	      <li ng-repeat="count in $ctrl.values">
 	        {{ count.count }}
 	      </li>
 	    </ul>
-
     </div>
   `
   });

--- a/src/services/queen.js
+++ b/src/services/queen.js
@@ -1,6 +1,6 @@
 angular.module('n-queens')
   .service('queen', function() {
-    this.runQueen = function(num) {
+    this.runQueen = function(num, setValues) {
       var values = [];
       var temp = '';
       for (let i = 0; i < num; i++) {
@@ -23,9 +23,10 @@ angular.module('n-queens')
           single.count = e.data;
           count += e.data;
           values.push(single);
+          setValues(values); // This is where setValues is called
         };
         myWorker.postMessage([ld, cols, rd, all]);
       }
-      return values;
+      // return values;
     }
   });


### PR DESCRIPTION
A couple things were happening here:

1) The worker.onmessage function is run ansynchronously, so the runQueen method returns an empty array and THEN worker.onmessage runs. You can breakpoint in chrome to see this (uncomment the return, breakpoint it, then breakpoint in the .onmessage). 

2) Once you realize the return is not working, you have to have the updated data get back to the appbody.js without using a return. The method you know for async stuff is callbacks, so I created a this.setValues function in appbody.js to act as a callback. Note that I converted the methods in appbody to regular es5 functions instead of arrow functions to make sure the this binding wasn't getting blown out. Turns out that wasn't the culprit, so you should be able to change them back.

3) Using the callback method turns into a this binding problem, because when the callback in appbody runs, you are setting this.values.... but at invocation time the callback is going to set its this binding to window. For this reason I had to redefine changeValue to a bound version of itself, then call runQueen with .call